### PR TITLE
Fix import errors when PySerial is not installed

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ setup(
         'numpy': ['numpy'],
         'Serial': ['pyserial'],
         'keithley': ['pyVISA'],
-        'prompt': ['pyreadline']
+        'prompt': ['pyreadline', 'scipy', 'matplotlib', 'ipython']
     },
     license='MIT'
 )

--- a/src/xtralien/__init__.py
+++ b/src/xtralien/__init__.py
@@ -14,8 +14,6 @@ import sys
 import threading
 import time
 
-from xtralien.serial_utils import serial_ports
-
 log_levels = {
     'debug': logging.DEBUG,
     'info': logging.INFO,
@@ -41,8 +39,10 @@ if sys.version_info.major < 3:
 # Try and import the serial module (supports USB-serial communication)
 try:
     import serial
+    from xtralien.serial_utils import serial_ports
 except ImportError:
     serial = None
+    serial_ports = lambda: ()
     logger.warning("The serial module was not found, USB not supported")
 
 

--- a/src/xtralien/prompt/__init__.py
+++ b/src/xtralien/prompt/__init__.py
@@ -1,4 +1,4 @@
-from xtralien.imports import *  # noqa: F403
+from xtralien.prompt.prelude import *  # noqa: F403
 
 
 def prompt(vars=None, message=""):

--- a/src/xtralien/prompt/prelude.py
+++ b/src/xtralien/prompt/prelude.py
@@ -26,7 +26,11 @@ from warnings import *  # noqa: F403
 # Xtralien
 import xtralien  # noqa: F401
 from xtralien import X100, Device  # noqa: F401
-from xtralien.serial_utils import serial_ports  # noqa: F401
+
+try:
+    from xtralien.serial_utils import serial_ports  # noqa: F401
+except ImportError:
+    print("The serial module was not found, USB not supported")
 
 # Scipy
 import scipy  # noqa: F401


### PR DESCRIPTION
The xtralien library does not work unless PySerial is installed, despite it being an "extra" in setup.py

This PR fixes the import problems so that the library will work without PySerial.

Also moved the `imports` module into `prompt` so that it's clearer what the purpose is.

Also added missing dependencies to setup.py. These are packages that need to be installed for the prompt to actually work without import errors.