### PR TITLE
Clean up Device.__call__()

### DIFF
--- a/src/xtralien/__init__.py
+++ b/src/xtralien/__init__.py
@@ -145,21 +145,18 @@ class Device(object):
     def command(self, command, returns=False, sleep_time=0.001):
         if sleep_time is not None:
             time.sleep(sleep_time)
-        if self.connections == []:
-            logger.error(
-                "Can't send command '{cmd}'\
-                because there are no open connections'".format(
-                    cmd=command
-                )
-            )
-        for conn in self.connections:
-            if True:  # try:
+
+        conn = None
+        try:
+            for conn in self.connections:
                 conn.write(command)
                 return conn.read(returns)
-            else:  # except (Exception, e):
-                # print(e)
+        except ConnectionError:
+            if conn is not None:
                 conn.close()
-                continue
+                self.connections.remove(conn)
+            raise
+
         logger.error(
             "Can't send command '{cmd}'\
             because there are no open connections".format(

--- a/src/xtralien/__init__.py
+++ b/src/xtralien/__init__.py
@@ -219,29 +219,28 @@ class Device(object):
         self.current_selection.append(x)
         return self
 
-    def __call__(self, *args, **kwargs):
-        sleep_time = kwargs.get('sleep_time', 0.001)
+    @staticmethod
+    def _default_formatter(x):
+        return x
+
+    def __call__(
+            self, *args,
+            sleep_time = 0.001,
+            format = 'auto',
+            response = True,
+            callback = None,
+    ):
         self.current_selection += args
-        returns = kwargs.get('response', True) or kwargs.get('callback', False)
+        returns = bool(response or callback)
         command = ' '.join([str(x) for x in self.current_selection])
         self.current_selection = []
 
-        def formatter(x):
-            return x
-
         if returns:
-            try:
-                formatter = self.formatters.get(
-                    kwargs.get('format', 'auto'),
-                    formatter
-                )
-            except KeyError:
-                if kwargs.get('format', None):
-                    logger.warning('Formatter not found')
+            formatter = self.formatters.get(format, self._default_formatter)
+        else:
+            formatter = self._default_formatter
 
-        callback = kwargs.get('callback', None)
-
-        if callback:
+        if callback is not None:
             def async_function():
                 while self.in_progress:
                     continue


### PR DESCRIPTION
Cleaned up some obvious issues in the code.

* Serialize async callbacks using an actual threading.Lock instead of an error-prone bool.  ***<<< This is probably the most important improvement. The way it was before, if an exception is thrown the device will be stuck permanently "in progress"***
* Make kwargs explicit in function signature.
* Remove dead branch, dict.get() will never raise KeyError.
* Replaced commented out try/catch. Close and remove connection if a ConnectionError is raised (while ensuring exception does not get silenced), remove redundant logging call.
* Replace the potentially fragile self-mutating current_selection system with a CommandBuilder class. This makes running a command a more pure computation with all of the mutation happening inside CommandBuilder only. Removed DeviceDuplicate as it no longer serves any useful purpose (you can just duplicate the CommandBuilder object directly).