### PR TITLE
Fix xtralien from messing up the global logging configuration

### DIFF
--- a/src/xtralien/__init__.py
+++ b/src/xtralien/__init__.py
@@ -23,7 +23,6 @@ log_levels = {
     'error': logging.ERROR
 }
 
-logging.basicConfig()
 logger = logging.getLogger('Xtralien')
 logger.setLevel(
     log_levels.get(os.getenv('LOG', 'warning').lower(), logging.WARNING)


### PR DESCRIPTION
I shouldn't have to explain how inappropriate it is for a library to be doing this.

Simply doing `import xtralien` will f**k with your application's logging configuration. I'm glad I didn't waste more time trying to figure out why nothing was being outputted to the logs before I found out that xtralien was the culprit.

